### PR TITLE
Remove indicator metadata tabs section

### DIFF
--- a/_includes/components/indicator/metadata-section.html
+++ b/_includes/components/indicator/metadata-section.html
@@ -1,0 +1,9 @@
+{%- comment -%}
+This file overrides the Open SDG theme include of the same path.
+
+We intentionally disable the entire metadata tab section on indicator pages:
+- National metadata
+- Global metadata (when applicable)
+- Sources
+- Edit buttons (staging)
+{%- endcomment -%}

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -76,3 +76,5 @@ body.layout-frontpage {
     }
   }
 }
+
+// (Intentionally left blank - indicator metadata tabs are disabled via template override.)


### PR DESCRIPTION
Disable the metadata/sources/edit tab block on indicator pages by overriding the theme include.